### PR TITLE
Use tmpdir instead of current dir for tempfile

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -625,7 +625,7 @@ shellpool_add_minus() {
     done
 }
 "
-               "(((bash " filename
+               "(((bash '" filename "'"
                " < /dev/null | shellpool_add_plus) 3>&1 1>&2 2>&3 | shellpool_add_minus) 2>&1"
                " ; printf \"\\n" +status-line+ " $?\\\n\" ) &" nl
                "echo " +pid-line+ " $! 1>&2" nl
@@ -652,7 +652,7 @@ shellpool_add_minus() {
            (stderr-exit   nil)
            (tempfile
             (cl-fad:with-output-to-temporary-file
-             (stream :template "shellpool-%.tmp")
+             (stream :template "temporary-files:shellpool-%.tmp")
              ;; Notes:
              ;;
              ;;  - We don't need a #!/???/bash line.  We will invoke the script


### PR DESCRIPTION
The default value for the `:template` argument of `cl-fad:open-temporary` (called by `cl-fad:with-output-to-temporary-file`) uses a logical pathname host `temporary-files` which is initialized in a system-dependent way.  This commit changes our call of `cl-fad:with-output-to-temporary-file` to use that logical pathname host as well.  The effect is that the tempfile will go into an appropriate tmpdir-like location (e.g. /tmp) instead of being written to the current directory.

This also fixes #13.