### PR TITLE
Avoid stripping out leading/trailing whitespace

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -597,7 +597,7 @@ shellpool_add_plus() {
     eof=\"\"
     while [ -z \"$eof\" ]
     do
-	read line || eof=1
+	IFS= read -r line || eof=1
 	if [ -z \"$eof\" ]
 	then
 	    echo \"+$line\";
@@ -614,7 +614,7 @@ shellpool_add_minus() {
     eof=\"\"
     while [ -z \"$eof\" ]
     do
-	read line || eof=1
+	IFS= read -r line || eof=1
 	if [ -z \"$eof\" ]
 	then
 	    echo \"-$line\";

--- a/test/basic.lisp
+++ b/test/basic.lisp
@@ -193,3 +193,5 @@
     (error "Started 2000 shells?")))
 
 
+(basic-test "echo \"  hello \""
+            :stdout '("  hello "))


### PR DESCRIPTION
This prevents whitespace from being stripped out from each line of the `shellpool:run` output, as mentioned in the issue #16.

The solution is to set `IFS= ` to prevent the `read` command from treating whitespace as a delimiter. (Unrelated, but the PR also adds the `-r` flag to avoid interpreting backslashes as a special escape character.)

It also adds a test to `test/basic.lisp` to cover this case.

I've tested this PR locally with CCL, just loading the `main.lisp` file followed by `test/basic.lisp`. I'm unsure if there is a better way to test the project.